### PR TITLE
Implement length() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ following observations:
   storage, unless used as input for further algorithms.
 - `uniq()`: Reduce the output by consecutive equality with `std::unique()`. Does not allocate
   temporary storage, unless used as input for further algorithms.
+- `length()`: Get the length of an input range. Uses `std::size()` if possible.
 
 ## TODO
 

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -405,6 +405,20 @@ TEST_CASE("ranges group_adjacent_by") {
     CHECK(group_vectors[3] == std::vector{1, 9}); // note: initializer list brokenness abound
 }
 
+TEST_CASE("range length") {
+    std::vector vector3{{0, 1, 2}};
+    int array4[] = {0, 1, 2, 3};
+    auto take5 = seq() | take(10) | filter([](int x) { return x % 2 == 1; });
+
+    auto vector3_size = vector3 | length();
+    auto array4_size = array4 | length();
+    auto take5_size = take5 | length();
+
+    CHECK(vector3_size == 3);
+    CHECK(array4_size == 4);
+    CHECK(take5_size == 5);
+}
+
 /*
 TEST_CASE("ranges append to non-container [no compile]") {
     double not_a_container = 0;


### PR DESCRIPTION
Get the length of an input range. Uses std::size() if possible.

The function is called length() instead of size() in order not to clash with std::size().