### PR TITLE
Add windowed(): Sliding window over an input range

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Algorithms that produce ranges from the output of other ranges.
   reach their end.
 - `zip()`: Produce tuples of values from multiple input ranges, until one of the ranges reaches its
   end.
+- `windowed(n, step=1)`: Sliding window of width `n` over an input range.
 
 ### Aggregators
 

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -582,6 +582,41 @@ TEST_CASE("ranges ad-hoc lambdas") {
     CHECK(result == std::vector{{1, 3, 5, 7, 9}});
 }
 
+TEST_CASE("ranges windowed") {
+    auto actual = seq() | take(3) | windowed(3) | to_vector();
+    auto expected = std::vector{{std::deque<int>{{0,1,2}}}};
+    CHECK(actual == expected);
+
+    actual = seq() | take(5) | windowed(3) | to_vector();
+    expected = std::vector{{
+        std::deque<int>{{0,1,2}},
+        std::deque<int>{{1,2,3}},
+        std::deque<int>{{2,3,4}}}};
+    CHECK(actual == expected);
+
+    actual = seq() | take(5) | windowed(3, 2) | to_vector();
+    expected = std::vector{{
+        std::deque<int>{{0,1,2}},
+        std::deque<int>{{2,3,4}}}};
+    CHECK(actual == expected);
+
+    actual = seq() | take(5) | windowed(3, 3) | to_vector();
+    expected = std::vector{{
+        std::deque<int>{{0,1,2}},
+        std::deque<int>{{3,4}}}};
+    CHECK(actual == expected);
+
+    actual = seq() | take(5) | windowed(3, 4) | to_vector();
+    expected = std::vector{{
+        std::deque<int>{{0,1,2}},
+        std::deque<int>(1, 4)}};
+    CHECK(actual == expected);
+
+    actual = seq() | take(5) | windowed(3, 5) | to_vector();
+    expected = std::vector{{std::deque<int>{{0,1,2}}}};
+    CHECK(actual == expected);
+}
+
 /*
 TEST_CASE("ranges append to non-container [no compile]") {
     double not_a_container = 0;


### PR DESCRIPTION
E.g. for a range `(1,2,3,4,5)` a window of 2 elements is `[(1,2), (2,3), (3,4), (5)]`. For a range  `(1,2,3,4,5,6)` a window of 2 elements with a stepsize of 3 is `[(1,2), (4,5)]`.

Inspired by [more_itertools.windowed()][1].

  [1]: https://more-itertools.readthedocs.io/en/v7.2.0/api.html#more_itertools.windowed