### PR TITLE
Do not use std::vector in group_adjacent_by()

### DIFF
--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1130,9 +1130,8 @@ struct in_groups_of {
     @brief Produce consecutive groups of elements for which P returns the same value, according to
     the Compare function.
 
-    The output type is `std::vector<N>` const reference, where T is the output type of the inner
-    range (without cvref-qualifiers). The size of the vector is indeterminate, but always greater
-    than 0.
+    The output type is a range of the same types as the input. The size of the range is
+    indeterminate, but always greater than 0.
 
     @tparam P The discriminant function. When the return value of this function changes, according
               to Compare, a new group is emitted.

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -373,7 +373,7 @@ TEST_CASE("ranges in_groups_of") {
 }
 
 TEST_CASE("ranges group_adjacent_by") {
-    const auto input = seq() | take(10) | to_vector();
+    const auto input = seq() | take(10);
 
     auto pred = [](int x) {
         return x / 3;
@@ -391,13 +391,13 @@ TEST_CASE("ranges group_adjacent_by") {
     for (auto it = begin(groups); it != end(groups); ++it) {
         const auto& group = *it;
         for (auto x : group) {
-            CHECK(pred(x) == pred(group[0]));
+            CHECK(pred(x) == pred(group.get()));
             CHECK(pred(x) != previous);
         }
-        previous = pred(group[0]);
+        previous = pred(group.get());
     }
 
-    auto group_vectors = groups | to_vector(); // vector<vector<int>>;
+    auto group_vectors = groups | transform(to_vector()) | to_vector();
     CHECK(group_vectors.size() == 4);
     CHECK(group_vectors[0] == std::vector{{0, 1, 2}});
     CHECK(group_vectors[1] == std::vector{{3, 4, 5}});


### PR DESCRIPTION
Using std::vector you have runtime memory allocations, and an O(N) space complexity.

This PR makes group_adjacent_by() generate ranges, too. You can always use transform(to_vector()) if working with vectors is more convenient.