### PR TITLE
Implement zip_longest, fix zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ following observations:
 - `uniq()`: Reduce the output by consecutive equality with `std::unique()`. Does not allocate
   temporary storage, unless used as input for further algorithms.
 - `cycle()`: Create an infinite range repeating the input elements in a loop.
+- `zip_longest()`: Produce tuples of values from multiple input ranges, until all of the ranges
+  reach their end.
 
 ## TODO
 

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1119,19 +1119,40 @@ struct ZipRange {
     constexpr explicit ZipRange(std::tuple<Tx...>&& tuple) : inputs(tuple) {}
 
     [[nodiscard]] constexpr output_type get() const noexcept {
-        return output_type(std::forward_as_tuple(std::get<Inputs>(inputs).get()...));
+        return _get(std::index_sequence_for<Inputs...>{});
     }
 
     constexpr void next() noexcept {
-        (std::get<Inputs>(inputs).next(), ...);
+        _next(std::index_sequence_for<Inputs...>{});
     }
 
     [[nodiscard]] constexpr bool at_end() const noexcept {
-        return (std::get<Inputs>(inputs).at_end() || ...);
+        return _at_end(std::index_sequence_for<Inputs...>{});
     }
 
     constexpr size_t size_hint() const noexcept {
-        return std::min({std::get<Inputs>(inputs).size_hint()...});
+        return _size_hint(std::index_sequence_for<Inputs...>{});
+    }
+
+private:
+    template <size_t... Index>
+    [[nodiscard]] constexpr output_type _get(std::index_sequence<Index...>) const noexcept {
+        return output_type(std::forward_as_tuple(std::get<Index>(inputs).get()...));
+    }
+
+    template <size_t... Index>
+    constexpr void _next(std::index_sequence<Index...>) noexcept {
+        (std::get<Index>(inputs).next(), ...);
+    }
+
+    template <size_t... Index>
+    [[nodiscard]] constexpr bool _at_end(std::index_sequence<Index...>) const noexcept {
+        return (std::get<Index>(inputs).at_end() || ...);
+    }
+
+    template <size_t... Index>
+    constexpr size_t _size_hint(std::index_sequence<Index...>) const noexcept {
+        return std::min({std::get<Index>(inputs).size_hint()...});
     }
 };
 template <class... Inputs>

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -2067,6 +2067,70 @@ struct cycle {
     }
 };
 
+template <class... Inputs>
+struct ZipLongestRange {
+    static_assert(sizeof...(Inputs) > 0);
+
+    std::tuple<Inputs...> inputs;
+    using output_type = std::tuple<RX_OPTIONAL<remove_cvref_t<typename Inputs::output_type>>...>;
+    static constexpr bool is_finite = (is_finite_v<Inputs> && ...);
+    static constexpr bool is_idempotent = (is_idempotent_v<Inputs> && ...);
+
+    template <class... Tx>
+    constexpr explicit ZipLongestRange(std::tuple<Tx...>&& tuple) : inputs(tuple) {}
+
+    [[nodiscard]] constexpr output_type get() const noexcept {
+        return _get(std::index_sequence_for<Inputs...>{});
+    }
+
+    constexpr void next() noexcept {
+        _next(std::index_sequence_for<Inputs...>{});
+    }
+
+    [[nodiscard]] constexpr bool at_end() const noexcept {
+        return _at_end(std::index_sequence_for<Inputs...>{});
+    }
+
+    constexpr size_t size_hint() const noexcept {
+        return _size_hint(std::index_sequence_for<Inputs...>{});
+    }
+
+private:
+    template <size_t... Index>
+    [[nodiscard]] constexpr output_type _get(std::index_sequence<Index...>) const noexcept {
+        return output_type(std::forward_as_tuple((std::get<Index>(inputs) | first())...));
+    }
+
+    template <size_t... Index>
+    constexpr void _next(std::index_sequence<Index...>) noexcept {
+        ((std::get<Index>(inputs).at_end() ? 0 : (std::get<Index>(inputs).next(), 0)), ...);
+    }
+
+    template <size_t... Index>
+    [[nodiscard]] constexpr bool _at_end(std::index_sequence<Index...>) const noexcept {
+        return (std::get<Index>(inputs).at_end() && ...);
+    }
+
+    template <size_t... Index>
+    constexpr size_t _size_hint(std::index_sequence<Index...>) const noexcept {
+        return std::max({std::get<Index>(inputs).size_hint()...});
+    }
+};
+template <class... Inputs>
+ZipLongestRange(std::tuple<Inputs...> &&)->ZipLongestRange<remove_cvref_t<Inputs>...>;
+
+/*!
+    @brief Zip two or more ranges, return longest range.
+    Until all of the ranges are at end, produce a tuple of an element from each range.
+    The ranges are not required to produce the same number of elements, and elements will be
+    produced until all of the ranges reach their end. Ranges that ended earlier produce nullopt.
+*/
+template <class... Inputs>
+[[nodiscard]] constexpr auto zip_longest(Inputs&&... inputs) noexcept {
+    // For some reason, argument deduction doesn't work here.
+    return ZipLongestRange(std::forward_as_tuple(as_input_range(std::forward<Inputs>(inputs))...));
+}
+
 } // namespace RX_NAMESPACE
 
 #endif // RX_RANGES_HPP_INCLUDED

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -488,6 +488,25 @@ TEST_CASE("ranges cycle") {
     auto zero_one_two = seq() | take(3) | cycle() | take(10) | to_vector();
     CHECK(zero_one_two == std::vector{{0, 1, 2, 0, 1, 2, 0, 1, 2, 0}});
 }
+
+TEST_CASE("ranges zip_longest") {
+    auto input1 = seq() | first_n(5);
+    auto input2 = input1 | transform(&to_string<int>);
+    auto input3 = seq(10) | first_n(7);
+    auto zipped = zip_longest(input1, input2, input3) | to_vector();
+    CHECK(zipped.size() == 7);
+    auto expected = std::vector{
+        std::make_tuple(RX_OPTIONAL(0), RX_OPTIONAL("0"s), RX_OPTIONAL(10)),
+        std::make_tuple(RX_OPTIONAL(1), RX_OPTIONAL("1"s), RX_OPTIONAL(11)),
+        std::make_tuple(RX_OPTIONAL(2), RX_OPTIONAL("2"s), RX_OPTIONAL(12)),
+        std::make_tuple(RX_OPTIONAL(3), RX_OPTIONAL("3"s), RX_OPTIONAL(13)),
+        std::make_tuple(RX_OPTIONAL(4), RX_OPTIONAL("4"s), RX_OPTIONAL(14)),
+        std::make_tuple(RX_OPTIONAL<int>(), RX_OPTIONAL<std::string>(), RX_OPTIONAL(15)),
+        std::make_tuple(RX_OPTIONAL<int>(), RX_OPTIONAL<std::string>(), RX_OPTIONAL(16)),
+    };
+    CHECK(zipped == expected);
+}
+
 /*
 TEST_CASE("ranges append to non-container [no compile]") {
     double not_a_container = 0;

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -109,6 +109,15 @@ TEST_CASE("ranges zip") {
     CHECK(zipped == expected);
 }
 
+TEST_CASE("ranges zip two same") {
+    auto add = [](auto lr) {
+        auto [l, r] = lr;
+        return l + r;
+    };
+    auto value = zip(seq(0), seq(1)) | first_n(5) | transform(add) | max();
+    CHECK(value == 9);
+}
+
 TEST_CASE("ranges zip reentrant") {
     auto input1 = seq() | first_n(5);
     auto input2 = input1 | transform(&to_string<int>);


### PR DESCRIPTION
Rebased on #10.

- `zip_longest()`: Produce tuples of values from multiple input ranges, until all of the ranges reach their end.
- It was not possible to use e.g. `zip(seq(), seq())`.