### PR TITLE
 Add: chain(), return values from multiple ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ following observations:
   storage, unless used as input for further algorithms.
 - `uniq()`: Reduce the output by consecutive equality with `std::unique()`. Does not allocate
   temporary storage, unless used as input for further algorithms.
+- `empty_range()`: A range that is always empty.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ following observations:
 - `uniq()`: Reduce the output by consecutive equality with `std::unique()`. Does not allocate
   temporary storage, unless used as input for further algorithms.
 - `empty_range()`: A range that is always empty.
+- `chain()`: Return values from multiple ranges, one after another.
 
 ## TODO
 

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -2012,6 +2012,17 @@ struct reverse {
     }
 };
 
+/// A range that is always empty.
+template <class T>
+struct empty_range : public iterator_range<T*> {
+    constexpr empty_range() noexcept : iterator_range<T*>(nullptr, nullptr) {}
+    template <class A>
+    constexpr empty_range(A&&) noexcept : empty_range() {}
+};
+empty_range()->empty_range<int>;
+template <class T>
+empty_range(T&&)->empty_range<remove_cvref_t<T>>;
+
 } // namespace RX_NAMESPACE
 
 #endif // RX_RANGES_HPP_INCLUDED

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1863,7 +1863,21 @@ struct append {
     }
 };
 template <class C>
+struct append <C&&> {
+    C out;
+    constexpr explicit append(C&& out) : out(std::move(out)) {}
+
+    template <class R>
+    [[nodiscard]] constexpr C operator()(R&& range) && {
+        // Note: sink() only advances the input range if it is actually an rvalue reference.
+        sink(std::forward<R>(range), out);
+        return std::move(out);
+    }
+};
+template <class C>
 append(C&)->append<C>;
+template <class C>
+append(C&&)->append<C&&>;
 
 /// Sorting sink.
 ///

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -2023,6 +2023,106 @@ empty_range()->empty_range<int>;
 template <class T>
 empty_range(T&&)->empty_range<remove_cvref_t<T>>;
 
+template <class... Rs>
+struct ChainRange {
+    static_assert(sizeof...(Rs) >= 2);
+
+    static constexpr bool is_finite = (is_finite_v<Rs> && ...);
+    static constexpr bool is_idempotent = (is_idempotent_v<Rs> && ...);
+    using output_type = std::common_type_t<typename Rs::output_type...>;
+
+    std::tuple<Rs...> inner_tpl;
+    size_t n = 0;
+
+    template <class... Rx>
+    explicit constexpr ChainRange(Rx&&... inner_tpl) : inner_tpl(std::forward<Rx>(inner_tpl)...) {
+        _skip_to_data(std::make_index_sequence<sizeof...(Rs)>{});
+    }
+
+    [[nodiscard]] output_type get() const noexcept {
+        RX_ASSERT(!at_end());
+        return _get(std::make_index_sequence<sizeof...(Rs)>{});
+    }
+
+    [[nodiscard]] bool at_end() const noexcept {
+        return n == sizeof...(Rs);
+    }
+
+    constexpr void next() noexcept {
+        RX_ASSERT(!at_end());
+        _next(std::make_index_sequence<sizeof...(Rs)>{});
+    }
+
+    [[nodiscard]] constexpr size_t size_hint() const noexcept {
+        return _size_hint(std::make_index_sequence<sizeof...(Rs)>{});
+    }
+
+private:
+    template <std::size_t... Index>
+    constexpr size_t _size_hint(std::index_sequence<Index...>) const {
+        return (0 + ... + std::get<Index>(inner_tpl).size_hint());
+    }
+
+    template <std::size_t... Index>
+    constexpr void _next(std::index_sequence<Index...>) noexcept {
+        using Fn = bool(*)(ChainRange&);
+        constexpr Fn fns[] = { &_next_at<Index>... };
+        if (RX_UNLIKELY(fns[n](*this))) {
+            _skip_to_data(std::make_index_sequence<sizeof...(Rs)>{});
+        }
+    }
+
+    template <std::size_t Index>
+    static constexpr bool _next_at(ChainRange &self) {
+        auto &inner = std::get<Index>(self.inner_tpl);
+        inner.next();
+        return inner.at_end();
+    }
+
+    template <std::size_t... Index>
+    constexpr output_type _get(std::index_sequence<Index...>) const {
+        using Fn = output_type(*)(const ChainRange&);
+        constexpr Fn fns[] = { &_get_at<Index>... };
+        return fns[n](*this);
+    }
+
+    template <std::size_t Index>
+    static constexpr output_type _get_at(const ChainRange &self) {
+        return { std::get<Index>(self.inner_tpl).get() };
+    }
+
+    template <std::size_t... Index>
+    constexpr void _skip_to_data(std::index_sequence<Index...>) {
+        using Fn = bool(*)(const ChainRange&);
+        constexpr Fn fns[] = { &_at_end_at<Index>... };
+        do {
+            if (RX_LIKELY(!fns[n](*this))) {
+                return;
+            }
+            ++n;
+        } while (n < sizeof...(Rs));
+    }
+
+    template <std::size_t Index>
+    static constexpr bool _at_end_at(const ChainRange &self) {
+        return std::get<Index>(self.inner_tpl).at_end();
+    }
+};
+
+/// Return values from multiple ranges.
+///
+/// Once the first range is exhausted, values from the second range are returned, and so on.
+template <class... InputRanges>
+[[nodiscard]] constexpr auto chain(InputRanges&&... inputs) {
+    if constexpr (sizeof...(InputRanges) == 0) {
+        return empty_range();
+    } else if constexpr (sizeof...(InputRanges) == 1) {
+        return std::get<0>(std::forward_as_tuple(as_input_range(std::forward<InputRanges>(inputs))...));
+    } else {
+        return ChainRange<get_range_type_t<InputRanges>...>{as_input_range(std::forward<InputRanges>(inputs))...};
+    }
+}
+
 } // namespace RX_NAMESPACE
 
 #endif // RX_RANGES_HPP_INCLUDED

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -474,6 +474,34 @@ TEST_CASE("ranges empty_range") {
     CHECK((empty_range("test"s) | to_vector()) == std::vector<std::string>());
 }
 
+TEST_CASE("ranges chain") {
+    // 0 arguments
+    static_assert(std::is_same_v<decltype(chain()), decltype(empty_range())>);
+
+    // 1 argument
+    static_assert(std::is_same_v<decltype(chain(seq())), decltype(seq())>);
+
+    // 2 arguments
+    auto homogenous_actual = chain("hello"s, "world"s) | append(""s);
+    auto homogenous_expected = "helloworld"s;
+    CHECK(homogenous_actual == homogenous_expected);
+
+    // 3 arguments
+    auto heterogeneous_actual = chain(seq() | take(4), "test"s, seq()) | take(10) | to_vector();
+    auto heterogeneous_expected = std::vector<int>{{0,1,2,3,'t','e','s','t',0,1}};
+    CHECK(heterogeneous_actual == heterogeneous_expected);
+
+    // Ensure ranges inbetween can be empty.
+    homogenous_actual = chain(""s, "hello"s, "world"s) | append(""s);
+    CHECK(homogenous_actual == homogenous_expected);
+
+    homogenous_actual = chain("hello"s, ""s, "world"s) | append(""s);
+    CHECK(homogenous_actual == homogenous_expected);
+
+    homogenous_actual = chain("hello"s, "world"s, ""s) | append(""s);
+    CHECK(homogenous_actual == homogenous_expected);
+}
+
 /*
 TEST_CASE("ranges append to non-container [no compile]") {
     double not_a_container = 0;

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -469,6 +469,11 @@ TEST_CASE("ranges non-default-constructible, non-copyable predicate") {
     }
 }
 
+TEST_CASE("ranges empty_range") {
+    CHECK((empty_range() | count()) == 0);
+    CHECK((empty_range("test"s) | to_vector()) == std::vector<std::string>());
+}
+
 /*
 TEST_CASE("ranges append to non-container [no compile]") {
     double not_a_container = 0;


### PR DESCRIPTION
Once the first range is exhausted, values from the second range are returned, and so on.

Inspired by [itertools.chain()][1].

[1]: https://docs.python.org/3.8/library/itertools.html#itertools.chain