### PR TITLE
Relax `idempotent_range` requirement

### DIFF
--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -818,7 +818,7 @@ struct transform {
         transform transform_;
         using output_type = decltype(std::declval<const F&>()((input_.get())));
         static constexpr bool is_finite = is_finite_v<InputRange>;
-        static constexpr bool is_idempotent = is_idempotent_v<InputRange>;
+        static constexpr bool is_idempotent = false; // `func` is called each time `get` is called
 
         constexpr Range(InputRange input, transform transform) noexcept
             : input_(std::move(input)), transform_(std::move(transform)) {}

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -55,6 +55,15 @@ TEST_CASE("range filter reentrant") {
     CHECK(a == b);
 }
 
+TEST_CASE("range filter idempotent") {
+    auto input = std::vector{{1, 2, 3, 4}};
+    int idempotent_guard{0};
+    auto odd = input | transform([&idempotent_guard] (int i) { ++idempotent_guard; return i; }) | filter([](int x) { return x % 2 == 1; });
+    auto a = odd | to_vector();
+    CHECK(a == std::vector{{1,3}});
+    CHECK(idempotent_guard == 4);
+}
+
 TEST_CASE("range first") {
     auto input = std::vector{{"Hello"s, "World"s, "Morty"s}};
     auto contains_y = [](std::string_view sv) { return sv.find('y') != std::string::npos; };


### PR DESCRIPTION
`idempotent_range` was requiring the type to be default-constructible and move assignable. By using `RX_OPTIONAL`, it can be lower to just move-constructible.

`transform` was not idempotent, because the internal transformer can mutate its internal state, possibly changing its result.

This then fix #1, because `filter` insert an `idempotent_range` after a `transform`. Test added.

Lowering the requirement was needed to pass the test "ranges non-default-constructible".
