### PR TITLE
Fix: make fill() and fill_n() work with lvalues

### DIFF
--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -749,9 +749,9 @@ seq(T, U)->seq<T, U>;
     @brief Generate infinite copies of type T.
 */
 template <class T>
-struct repeat {
+struct fill {
     T value;
-    constexpr explicit repeat(T value) noexcept : value(std::move(value)) {}
+    constexpr explicit fill(T value) noexcept : value(std::move(value)) {}
 
     using output_type = T;
     static constexpr bool is_finite = false;
@@ -772,12 +772,7 @@ struct repeat {
     }
 };
 template <class T>
-repeat(T &&)->repeat<T>;
-
-template <class T>
-[[nodiscard]] constexpr auto fill(T&& v) {
-    return repeat(std::forward<T>(v));
-}
+fill(T &&)->fill<T>;
 
 /*!
     @brief Generate N copies of type T.
@@ -785,7 +780,7 @@ template <class T>
     This is equivalent to `fill(value) | take(n)`.
 */
 template <class T>
-struct repeat_n {
+struct fill_n {
     using output_type = const T&;
     static constexpr bool is_finite = true;
     static constexpr bool is_idempotent = true;
@@ -793,7 +788,7 @@ struct repeat_n {
     T value;
     size_t n;
     size_t i = 0;
-    constexpr explicit repeat_n(size_t n, T value) : value(std::move(value)), n(n) {}
+    constexpr explicit fill_n(size_t n, T value) : value(std::move(value)), n(n) {}
 
     constexpr void next() {
         RX_ASSERT(!at_end());
@@ -811,12 +806,7 @@ struct repeat_n {
     }
 };
 template <class T>
-repeat_n(size_t, T &&)->repeat_n<T>;
-
-template <class T>
-[[nodiscard]] constexpr auto fill_n(size_t n, T&& v) noexcept {
-    return repeat_n(n, std::forward<T>(v));
-}
+fill_n(T &&)->fill_n<T>;
 
 /*!
     @brief Transform a range of values by a function F.

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -772,7 +772,7 @@ struct fill {
     }
 };
 template <class T>
-fill(T &&)->fill<T>;
+fill(T&&)->fill<remove_cvref_t<T>>;
 
 /*!
     @brief Generate N copies of type T.
@@ -806,7 +806,7 @@ struct fill_n {
     }
 };
 template <class T>
-fill_n(T &&)->fill_n<T>;
+fill_n(T&&)->fill_n<remove_cvref_t<T>>;
 
 /*!
     @brief Transform a range of values by a function F.

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -775,40 +775,6 @@ template <class T>
 fill(T&&)->fill<remove_cvref_t<T>>;
 
 /*!
-    @brief Generate N copies of type T.
-
-    This is equivalent to `fill(value) | take(n)`.
-*/
-template <class T>
-struct fill_n {
-    using output_type = const T&;
-    static constexpr bool is_finite = true;
-    static constexpr bool is_idempotent = true;
-
-    T value;
-    size_t n;
-    size_t i = 0;
-    constexpr explicit fill_n(size_t n, T value) : value(std::move(value)), n(n) {}
-
-    constexpr void next() {
-        RX_ASSERT(!at_end());
-        ++i;
-    }
-    [[nodiscard]] constexpr output_type get() const noexcept {
-        RX_ASSERT(!at_end());
-        return value;
-    }
-    [[nodiscard]] constexpr bool at_end() const noexcept {
-        return i == n;
-    }
-    constexpr size_t size_hint() const noexcept {
-        return n;
-    }
-};
-template <class T>
-fill_n(T&&)->fill_n<remove_cvref_t<T>>;
-
-/*!
     @brief Transform a range of values by a function F.
 
     Each output is produced by passing the output of the inner range to the function F.
@@ -990,6 +956,16 @@ struct take {
         return Range<Inner>{as_input_range(std::forward<InputRange>(input)), n};
     }
 };
+
+/*!
+    @brief Generate N copies of type T.
+
+    This is equivalent to `fill(value) | take(n)`.
+*/
+template <class T>
+constexpr auto fill_n(size_t n, T&& v) {
+    return fill(std::forward<T>(v)) | take(n);
+}
 
 /// Alias for `take()`.
 using first_n = take;

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -259,6 +259,12 @@ TEST_CASE("ranges fill") {
     std::string b;
     fill('b') | first_n(5) | append(b);
     CHECK(b == "bbbbb");
+
+    int v = 7;
+    CHECK((fill(v) | take(5) | sum()) == 7*5);
+    CHECK(v == 7);
+    CHECK((fill_n(5, v) | sum()) == 7*5);
+    CHECK(v == 7);
 }
 
 TEST_CASE("ranges sum") {


### PR DESCRIPTION
repeat_n was a combination of repeat and take with no advantages over keeping them separate. Instead of fixing the problem is two places, I removed the simply removed repeat_n.