### PR TITLE
Add: tee(), copy into container during iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ following observations:
 - `padded()`: Yield an infinite list of constant values once the input range is exhausted.
 - `zip_longest()`: Produce tuples of values from multiple input ranges, until all of the ranges
   reach their end.
+- `tee()`: Copy values of a range into a container during iteration.
 
 ## TODO
 

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -650,6 +650,11 @@ constexpr auto as_idempotent_input_range(R&& range) {
 template <class T>
 using get_range_type_t = remove_cvref_t<decltype(as_input_range(std::declval<T>()))>;
 
+// This function is analogous to get_range_type_t. Instead the result of as_input_range() it tells
+// you the result of as_idempotent_input_range().
+template <class T>
+using get_idempotent_range_type_t = remove_cvref_t<decltype(as_idempotent_input_range(std::declval<T>()))>;
+
 // Get the output type of T as if it was converted to a range. This is the output type of the input
 // range after conversion through `as_input_range()`.
 template <class T>
@@ -924,15 +929,13 @@ struct filter {
 
     template <class InputRange>
     [[nodiscard]] constexpr auto operator()(InputRange&& input) const& {
-        auto inner = as_idempotent_input_range(std::forward<InputRange>(input));
-        using Inner = decltype(inner);
-        return Range<Inner>{std::move(inner), pred};
+        using Inner = get_idempotent_range_type_t<InputRange>;
+        return Range<Inner>{as_idempotent_input_range(std::forward<InputRange>(input)), pred};
     }
     template <class InputRange>
     [[nodiscard]] constexpr auto operator()(InputRange&& input) && {
-        auto inner = as_idempotent_input_range(std::forward<InputRange>(input));
-        using Inner = decltype(inner);
-        return Range<Inner>{std::move(inner), std::move(pred)};
+        using Inner = get_idempotent_range_type_t<InputRange>;
+        return Range<Inner>{as_idempotent_input_range(std::forward<InputRange>(input)), std::move(pred)};
     }
 };
 template <class F>
@@ -1095,16 +1098,14 @@ struct until {
 
     template <class InputRange>
     constexpr auto operator()(InputRange&& input) const& {
-        auto inner = as_idempotent_input_range(std::forward<InputRange>(input));
-        using Inner = decltype(inner);
-        return Range<Inner>{std::move(inner), pred};
+        using Inner = get_idempotent_range_type_t<InputRange>;
+        return Range<Inner>{as_idempotent_input_range(std::forward<InputRange>(input)), pred};
     }
 
     template <class InputRange>
     constexpr auto operator()(InputRange&& input) && {
-        auto inner = as_idempotent_input_range(std::forward<InputRange>(input));
-        using Inner = decltype(inner);
-        return Range<Inner>{std::move(inner), std::move(pred)};
+        using Inner = get_idempotent_range_type_t<InputRange>;
+        return Range<Inner>{as_idempotent_input_range(std::forward<InputRange>(input)), std::move(pred)};
     }
 };
 template <class P>

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -563,6 +563,18 @@ TEST_CASE("ranges zip_longest") {
     CHECK(zipped == expected);
 }
 
+TEST_CASE("ranges tee") {
+    auto container1 = std::vector(0, 0);
+    auto container2 = std::vector(0, 0);
+    seq() | tee(container1) | take(10) | append(container2);
+    CHECK(container1 == container2);
+
+    container1.clear();
+    auto value = seq() | tee(container1) | take(10) | sum();
+    CHECK(container1 == container2);
+    CHECK(value == 9 * 10 / 2);
+}
+
 /*
 TEST_CASE("ranges append to non-container [no compile]") {
     double not_a_container = 0;


### PR DESCRIPTION
This change also moves the inside of sink() into its own function: sink_one()