### PR TITLE
Add: padded(), yield an infinite list of constant values once the input range is exhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ following observations:
 - `uniq()`: Reduce the output by consecutive equality with `std::unique()`. Does not allocate
   temporary storage, unless used as input for further algorithms.
 - `cycle()`: Create an infinite range repeating the input elements in a loop.
+- `padded()`: Yield an infinite list of constant values once the input range is exhausted.
 
 ## TODO
 

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -2046,6 +2046,66 @@ struct cycle {
     }
 };
 
+/// Yield an infinite list of constant values once the input range is exhausted.
+template <class V>
+struct padded {
+    V value;
+    template <class Vx>
+    explicit constexpr padded(Vx&& value) noexcept : value(std::forward<Vx>(value)) {}
+
+    template <class R>
+    struct Range {
+        R input;
+        const V value;
+
+        using output_type = std::common_type_t<remove_cvref_t<get_output_type_of_t<R>>, V>;
+        static constexpr bool is_finite = false;
+        static constexpr bool is_idempotent = is_idempotent_v<R>;
+
+        template <class Rx, class Vx>
+        constexpr Range(Rx&& input, Vx&& value) noexcept
+            : input(std::forward<Rx>(input)), value(std::forward<Vx>(value)) {}
+
+        constexpr void next() {
+            if (!input.at_end()) {
+                input.next();
+            }
+        }
+
+        [[nodiscard]] constexpr output_type get() const {
+            if (!input.at_end()) {
+                return input.get();
+            } else {
+                return value;
+            }
+        }
+
+        [[nodiscard]] constexpr bool at_end() const {
+            return false;
+        }
+
+        [[nodiscard]] constexpr size_t size_hint() const noexcept {
+            return std::numeric_limits<size_t>::max();
+        }
+    };
+
+    template <class InputRange>
+    [[nodiscard]] constexpr auto operator()(InputRange&& input) const& noexcept {
+        using Inner = get_range_type_t<InputRange>;
+        return Range<Inner>{as_input_range(std::forward<InputRange>(input)), value};
+    }
+
+    template <class InputRange>
+    [[nodiscard]] constexpr auto operator()(InputRange&& input) && noexcept {
+        using Inner = get_range_type_t<InputRange>;
+        return Range<Inner>{as_input_range(std::forward<InputRange>(input)), std::move(value)};
+    }
+};
+template <class V>
+padded(V&)->padded<remove_cvref_t<V>>;
+template <class V>
+padded(V&&)->padded<remove_cvref_t<V>>;
+
 } // namespace RX_NAMESPACE
 
 #endif // RX_RANGES_HPP_INCLUDED

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -479,6 +479,13 @@ TEST_CASE("ranges cycle") {
     auto zero_one_two = seq() | take(3) | cycle() | take(10) | to_vector();
     CHECK(zero_one_two == std::vector{{0, 1, 2, 0, 1, 2, 0, 1, 2, 0}});
 }
+
+TEST_CASE("ranges padded") {
+    auto actual = seq() | take(3) | padded(-1) | take(5) | to_vector();
+    auto expected = std::vector{{0,1,2,-1,-1}};
+    CHECK(actual == expected);
+}
+
 /*
 TEST_CASE("ranges append to non-container [no compile]") {
     double not_a_container = 0;


### PR DESCRIPTION
Inspired by [more_itertools.padded()][1].

[1]: https://more-itertools.readthedocs.io/en/v7.2.0/api.html#more_itertools.padded