### PR TITLE
Introduce advance_by(), and emit ranges from groups

### DIFF
--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1020,8 +1020,19 @@ struct take {
 
         constexpr void advance_by(size_t m) noexcept {
             using RX_NAMESPACE::advance_by;
-            i += m;
-            advance_by(inner, m);
+            // Addition beyond n and integer overflow both clamp to the end.
+            size_t check = i + m;
+            bool int_did_overflow = check < i;
+            bool bounds_did_overflow = check > n;
+
+            if (!int_did_overflow && !bounds_did_overflow) {
+                advance_by(inner, m);
+                i += m;
+            } else if (i != n) {
+                advance_by(inner, n - i);
+                i = n;
+            }
+            RX_ASSERT((!int_did_overflow && !bounds_did_overflow) || at_end());
         }
     };
 

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1266,7 +1266,11 @@ template <class... Inputs>
 struct in_groups_of_exactly {
     const size_t n;
 
-    constexpr explicit in_groups_of_exactly(size_t n) noexcept : n(n) {}
+    constexpr explicit in_groups_of_exactly(size_t n) : n(n) {
+        if (n == 0) {
+            throw std::runtime_error("in_groups_of_exactly(0) is not allowed");
+        }
+    }
 
     template <class R>
     struct Range {

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -501,7 +501,7 @@ struct iterator_range {
                 return advanced;
             }
         } else {
-            size_t i;
+            size_t i = 0;
             for (i = 0; i < n && current_ != end_; ++i) {
                 next();
             }

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1167,6 +1167,10 @@ struct ZipRange {
         return _size_hint(std::index_sequence_for<Inputs...>{});
     }
 
+    constexpr void advance_by(size_t n) noexcept {
+        _advance_by(std::index_sequence_for<Inputs...>{}, n);
+    }
+
 private:
     template <size_t... Index>
     [[nodiscard]] constexpr output_type _get(std::index_sequence<Index...>) const noexcept {
@@ -1188,9 +1192,10 @@ private:
         return std::min({std::get<Index>(inputs).size_hint()...});
     }
 
-    constexpr void advance_by(size_t n) noexcept {
+    template <size_t... Index>
+    constexpr void _advance_by(std::index_sequence<Index...>, size_t n) noexcept {
         using RX_NAMESPACE::advance_by;
-        (advance_by(std::get<Inputs>(inputs), n), ...);
+        (advance_by(std::get<Index>(inputs), n), ...);
     }
 };
 template <class... Inputs>

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1050,45 +1050,14 @@ using first_n = take;
     @brief Create a range that skips the first N elements of its input.
 */
 struct skip_n {
-    size_t n;
+    const size_t n;
     constexpr explicit skip_n(size_t n) noexcept : n(n) {}
 
     template <class InputRange>
-    struct Range {
-        InputRange input_;
-        using output_type = typename InputRange::output_type;
-        static constexpr bool is_finite = is_finite_v<InputRange>;
-        static constexpr bool is_idempotent = is_idempotent_v<InputRange>;
-
-        constexpr Range(InputRange input, size_t n) noexcept : input_(std::move(input)) {
-            advance_by(n);
-        }
-
-        [[nodiscard]] constexpr output_type get() const noexcept {
-            return input_.get();
-        }
-
-        constexpr void next() noexcept {
-            input_.next();
-        }
-
-        constexpr bool at_end() const noexcept {
-            return input_.at_end();
-        }
-
-        constexpr size_t size_hint() const noexcept {
-            return input_.size_hint();
-        }
-
-        constexpr void advance_by(size_t n) noexcept {
-            using RX_NAMESPACE::advance_by;
-            advance_by(input_, n);
-        }
-    };
-    template <class InputRange>
     [[nodiscard]] constexpr auto operator()(InputRange&& input) const {
-        using Inner = get_range_type_t<InputRange>;
-        return Range<Inner>{as_input_range(std::forward<InputRange>(input)), n};
+        auto range = as_input_range(std::forward<InputRange>(input));
+        advance_by(range, n);
+        return range;
     }
 };
 

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1277,21 +1277,19 @@ struct in_groups_of_exactly {
 
         constexpr void next() noexcept {
             storage.reset();
-            if (!inner.at_end()) {
+            if (RX_LIKELY(!inner.at_end())) {
                 auto copy = as_input_range(inner);
                 using RX_NAMESPACE::advance_by;
-                if (n > 1) {
+                if (RX_LIKELY(n > 1)) {
                     advance_by(inner, n - 1);
                     if (inner.at_end()) {
                         // end was reached before we could produce a whole group.
                         storage.reset();
                         return;
                     }
-                    inner.next();
-                } else {
-                    // n cannot be zero
-                    inner.next();
                 }
+                // n cannot be zero
+                inner.next();
                 storage.emplace(std::move(copy) | take(n));
             }
         }

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1306,7 +1306,18 @@ struct in_groups_of_exactly {
             if (!inner.at_end()) {
                 auto copy = as_input_range(inner);
                 using RX_NAMESPACE::advance_by;
-                advance_by(inner, n);
+                if (n > 1) {
+                    advance_by(inner, n - 1);
+                    if (inner.at_end()) {
+                        // end was reached before we could produce a whole group.
+                        storage.reset();
+                        return;
+                    }
+                    inner.next();
+                } else {
+                    // n cannot be zero
+                    inner.next();
+                }
                 storage.emplace(std::move(copy) | take(n));
             }
         }

--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1343,11 +1343,8 @@ struct in_groups_of_exactly {
 /*!
     @brief Produce sequential groups of N or fewer elements.
 
-    The output type is `std::vector<N>` const reference, where T is the output type of the inner
-    range (without cvref-qualifiers), and the size of the result is never greater than N.
-
-    If the input produces a number of inputs that is not divisible by N, the last group produces
-    will have a size < N.
+    The output type is a range producing at most N elements. If the input produces a number of
+    inputs that is not divisible by N, the last group produces will have a size < N.
 */
 struct in_groups_of {
     size_t n;

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -24,6 +24,16 @@ std::string to_string(T val) {
 //     CHECK(s == "123");
 // }
 
+TEST_CASE("range take advance_by overflow") {
+    auto bounds = seq() | take(10);
+    advance_by(bounds, 11);
+    CHECK(bounds.i == bounds.n);
+
+    auto arithmetic = seq() | take(10);
+    advance_by(arithmetic, std::numeric_limits<size_t>::max());
+    CHECK(arithmetic.i == arithmetic.n);
+}
+
 TEST_CASE("range transform") {
     auto input = std::vector{{1, 2, 3, 4}};
     auto strings = input | transform(&to_string<int>) | to_vector();
@@ -330,7 +340,7 @@ TEST_CASE("ranges reverse") {
 }
 
 TEST_CASE("ranges in_groups_of_exactly, dynamic size") {
-    auto input = seq<float>() | take(1000) | to_vector();
+    auto input = seq<float>() | take(1001) | to_vector();
 
     size_t num_groups = input | in_groups_of_exactly(4) | count();
     CHECK(num_groups == 250);
@@ -350,7 +360,8 @@ TEST_CASE("ranges in_groups_of_exactly, dynamic size") {
 
     std::array<float, 4> expected_sums = {0.f, 0.f, 0.f, 0.f};
     for (auto [i, x] : enumerate(input)) {
-        expected_sums[i % 4] += x;
+        if (i != 1000)
+            expected_sums[i % 4] += x;
     }
 
     CHECK(sums == expected_sums);

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -568,6 +568,15 @@ TEST_CASE("ranges padded") {
     CHECK(actual == expected);
 }
 
+TEST_CASE("ranges padded advance_by") {
+    auto actual = seq() | take(3) | padded(-1);
+    CHECK(actual.get() == 0);
+    advance_by(actual, 2);
+    CHECK(actual.get() == 2);
+    advance_by(actual, 1);
+    CHECK(actual.get() == -1);
+}
+
 TEST_CASE("ranges zip_longest") {
     auto input1 = seq() | first_n(5);
     auto input2 = input1 | transform(&to_string<int>);
@@ -584,6 +593,21 @@ TEST_CASE("ranges zip_longest") {
         std::make_tuple(RX_OPTIONAL<int>(), RX_OPTIONAL<std::string>(), RX_OPTIONAL(16)),
     };
     CHECK(zipped == expected);
+}
+
+TEST_CASE("ranges zip_longest advance_by") {
+    auto input1 = seq() | first_n(5);
+    auto input2 = input1 | transform(&to_string<int>);
+    auto input3 = seq(10) | first_n(7);
+    auto zipped = zip_longest(input1, input2, input3);
+    advance_by(zipped, 4);
+    auto expected1 = std::make_tuple(RX_OPTIONAL(4), RX_OPTIONAL("4"s), RX_OPTIONAL(14));
+    CHECK(zipped.get() == expected1);
+    advance_by(zipped, 2);
+    auto expected2 = std::make_tuple(RX_OPTIONAL<int>(), RX_OPTIONAL<std::string>(), RX_OPTIONAL(16));
+    CHECK(zipped.get() == expected2);
+    advance_by(zipped, 1);
+    CHECK(zipped.at_end());
 }
 
 TEST_CASE("ranges tee") {

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -135,6 +135,10 @@ TEST_CASE("ranges zip two same") {
     };
     auto value = zip(seq(0), seq(1)) | first_n(5) | transform(add) | max();
     CHECK(value == 9);
+
+    auto advancing = zip(seq(0), seq(1)) | transform(add);
+    advance_by(advancing, 4);
+    CHECK(advancing.get() == 9);
 }
 
 TEST_CASE("ranges zip advance_by") {


### PR DESCRIPTION
Introduces a new (optional) feature of ranges: `advance_by(size_t)`.

For some ranges, like most iterators, it is possible to skip over multiple elements at once. This is especially useful in grouping combinators, `skip()`, etc.

In benchmarks, this improved the performance of `in_groups_of()` by 200x...!

Additionally, `in_groups_of_exactly<N>()` was removed, because synthetic benchmarks showed that updating the internal storage in `std::array` was much more expensive than emitting a copied subrange.