### PR TITLE
 Fix: until() is (most likely) finite

### DIFF
--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1070,7 +1070,7 @@ struct until {
     struct Range {
         static_assert(is_idempotent_v<R>);
         using output_type = remove_cvref_t<typename R::output_type>;
-        static constexpr bool is_finite = is_finite_v<R>;
+        static constexpr bool is_finite = true;
         static constexpr bool is_idempotent = true;
 
         R input;
@@ -1109,7 +1109,7 @@ struct until {
         }
 
         constexpr size_t size_hint() const noexcept {
-            return input.size_hint();
+            return 0;
         }
     };
 

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -204,7 +204,7 @@ TEST_CASE("ranges generate reentrant") {
 }
 
 TEST_CASE("ranges until") {
-    auto input = seq() | until([](int x) { return x == 5; }) | take(10);
+    auto input = seq() | until([](int x) { return x == 5; });
     auto result = input | to_vector();
     auto expected = seq() | first_n(5) | to_vector();
     CHECK(result == expected);


### PR DESCRIPTION
This PR makes until() usable as an input to e.g. to_vector() without needing a take() guard.