### PR TITLE
Fix: rename member variable end for MSVC

### DIFF
--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -1075,13 +1075,13 @@ struct until {
 
         R input;
         P pred;
-        bool end = false;
+        bool done = false;
 
         template <class Rx, class Px>
         constexpr Range(Rx&& input, Px&& pred) noexcept
-            : input(std::forward<Rx>(input)), pred(std::forward<Px>(pred)), end(input.at_end()) {
-            if (!end) {
-                end = pred(input.get());
+            : input(std::forward<Rx>(input)), pred(std::forward<Px>(pred)), done(input.at_end()) {
+            if (!done) {
+                done = pred(input.get());
             }
         }
 
@@ -1098,14 +1098,14 @@ struct until {
         constexpr void next() noexcept {
             RX_ASSERT(!at_end());
             input.next();
-            end = input.at_end();
-            if (!end) {
-                end = pred(input.get());
+            done = input.at_end();
+            if (!done) {
+                done = pred(input.get());
             }
         }
 
         [[nodiscard]] constexpr bool at_end() const noexcept {
-            return end;
+            return done;
         }
 
         constexpr size_t size_hint() const noexcept {
@@ -1390,14 +1390,14 @@ struct in_groups_of {
         R inner;
         std::vector<element_type> storage;
         size_t n;
-        bool end = false;
+        bool done = false;
 
         Range(R inner, size_t n) : inner(std::move(inner)), n(n) {
             if (RX_LIKELY(!this->inner.at_end())) {
                 storage.reserve(n);
                 fill_group();
             } else {
-                end = true;
+                done = true;
             }
         }
 
@@ -1407,13 +1407,13 @@ struct in_groups_of {
         }
 
         [[nodiscard]] bool at_end() const noexcept {
-            return end;
+            return done;
         }
 
         void next() noexcept {
             RX_ASSERT(!at_end());
             if (inner.at_end()) {
-                end = true;
+                done = true;
             } else {
                 fill_group();
             }

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -383,11 +383,7 @@ TEST_CASE("ranges in_groups_of") {
     float last = 0.f;
     auto groups = input | in_groups_of(4);
 
-    // For some reason, MSVC does not correctly find begin()/end() via ADL in range-based for loops
-    // for this particular case. It's a bit of a mystery, since this works for all the other range
-    // types, and there doesn't seem to be any difference in how the in_groups_of() adapter works.
-    for (auto it = begin(groups); it != end(groups); ++it) {
-        auto& group = *it;
+    for (const auto& group : groups) {
         CHECK(group.size() != 0);
         if (group.size() == 4) {
             std::get<0>(sums) += group[0];
@@ -423,12 +419,8 @@ TEST_CASE("ranges group_adjacent_by") {
     size_t num_groups = groups | count();
     CHECK(num_groups == 4);
 
-    // For some reason, MSVC does not correctly find begin()/end() via ADL in range-based for loops
-    // for this particular case. It's a bit of a mystery, since this works for all the other range
-    // types, and there doesn't seem to be any difference in how the in_groups_of() adapter works.
     int previous = std::numeric_limits<int>::max();
-    for (auto it = begin(groups); it != end(groups); ++it) {
-        const auto& group = *it;
+    for (const auto& group : groups) {
         for (auto x : group) {
             CHECK(pred(x) == pred(group.get()));
             CHECK(pred(x) != previous);


### PR DESCRIPTION
Range-based loops does not work properly in MSVC if the range contains a member variable `end`. This PR renames such variables into `done`.