### PR TITLE
CI: Add benchmarks for Linux+Clang+libcxx, tests and benchmarks for macOS

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -115,7 +115,9 @@ jobs:
     - name: build
       run: ninja -C build
     - name: run tests
-      run: build/rx-ranges-test && build/rx-benchmark
+      run: build/rx-ranges-test
+    - name: run benchmarks
+      run: build/rx-benchmark
   Windows-MSVC-Benchmark:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,7 +6,7 @@ on:
   pull_request: []
 
 jobs:
-  GCC9:
+  Linux-GCC9:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -19,8 +19,10 @@ jobs:
     - name: build
       run: ninja -C build
     - name: run tests
-      run: build/rx-ranges-test && build/rx-calendar
-  Clang8:
+      run: build/rx-ranges-test
+    - name: run calendar example
+      run: build/rx-calendar
+  Linux-Clang8:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -33,8 +35,10 @@ jobs:
     - name: build
       run: ninja -C build
     - name: run tests
-      run: build/rx-ranges-test && build/rx-calendar
-  Clang8-Libcxx:
+      run: build/rx-ranges-test
+    - name: run calendar example
+      run: build/rx-calendar
+  Linux-Clang8-Libcxx:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -47,8 +51,10 @@ jobs:
     - name: build
       run: ninja -C build
     - name: run tests
-      run: build/rx-ranges-test && build/rx-calendar
-  MSVC:
+      run: build/rx-ranges-test
+    - name: run calendar example
+      run: build/rx-calendar
+  Windows-MSVC:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
@@ -64,7 +70,23 @@ jobs:
       run: build/Debug/rx-ranges-test.exe
     - name: run calendar example
       run: build/Debug/rx-calendar.exe
-  GCC9-Benchmark:
+  macOS-Clang:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install dependencies
+      run: brew install ninja boost
+    - name: make build dir
+      run: mkdir build
+    - name: configure
+      run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DRX_TEST=ON -GNinja && cd ..
+    - name: build
+      run: ninja -C build
+    - name: run tests
+      run: build/rx-ranges-test
+    - name: run calendar example
+      run: build/rx-calendar
+  Linux-GCC9-Benchmark:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -77,8 +99,10 @@ jobs:
     - name: build
       run: ninja -C build
     - name: run tests
-      run: build/rx-ranges-test && build/rx-benchmark
-  Clang8-Benchmark:
+      run: build/rx-ranges-test
+    - name: run benchmarks
+      run: build/rx-benchmark
+  Linux-Clang8-Benchmark:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -92,7 +116,7 @@ jobs:
       run: ninja -C build
     - name: run tests
       run: build/rx-ranges-test && build/rx-benchmark
-  MSVC-Benchmark:
+  Windows-MSVC-Benchmark:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
@@ -108,19 +132,35 @@ jobs:
       run: build/Release/rx-ranges-test.exe
     - name: run benchmarks
       run: build/Release/rx-benchmark.exe
-  # TODO: libbenchmark is built with libstdc++, so this segfaults on startup. We need to build
-  # libbenchmark ourselves.
-  # Clang8-libcxx-Benchmark:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - name: install dependencies
-  #     run: (sudo apt-get update && sudo apt-get install libbenchmark-dev libboost-date-time-dev doctest-dev ninja-build cmake build-essential clang-8 libc++-8-dev libc++abi-8-dev)
-  #   - name: make build dir
-  #     run: mkdir build
-  #   - name: configure
-  #     run: (cd build && cmake .. -G Ninja -DRX_TEST=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/usr/bin/clang++-8 -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-lc++ -lm -lc -lgcc_s -lgcc")
-  #   - name: build
-  #     run: ninja -C build
-  #   - name: run tests
-  #     run: build/rx-ranges-test && build/rx-benchmark
+  macOS-Clang-Benchmark:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install dependencies
+      run: brew install ninja boost
+    - name: make build dir
+      run: mkdir build
+    - name: configure
+      run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DRX_TEST=ON -GNinja && cd ..
+    - name: build
+      run: ninja -C build
+    - name: run tests
+      run: build/rx-ranges-test
+    - name: run benchmarks
+      run: build/rx-benchmark
+  Linux-Clang8-libcxx-Benchmark:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install dependencies
+      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev ninja-build cmake build-essential clang-8 libc++-8-dev libc++abi-8-dev)
+    - name: make build dir
+      run: mkdir build
+    - name: configure
+      run: (cd build && cmake .. -G Ninja -DRX_TEST=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/usr/bin/clang++-8 -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-lc++ -lm -lc -lgcc_s -lgcc")
+    - name: build
+      run: ninja -C build
+    - name: run tests
+      run: build/rx-ranges-test
+    - name: run benchmarks
+      run: build/rx-benchmark

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev libbenchmark-dev doctest-dev ninja-build cmake build-essential g++-9)
+      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev ninja-build cmake build-essential g++-9)
     - name: make build dir
       run: mkdir build
     - name: configure
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: (sudo apt-get update && sudo apt-get install libbenchmark-dev libboost-date-time-dev doctest-dev ninja-build cmake build-essential clang-8)
+      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev ninja-build cmake build-essential clang-8)
     - name: make build dir
       run: mkdir build
     - name: configure
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: (sudo apt-get update && sudo apt-get install libbenchmark-dev libboost-date-time-dev doctest-dev ninja-build cmake build-essential clang-8 libc++-8-dev libc++abi-8-dev)
+      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev ninja-build cmake build-essential clang-8 libc++-8-dev libc++abi-8-dev)
     - name: make build dir
       run: mkdir build
     - name: configure
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: '& "$Env:VCPKG_INSTALLATION_ROOT/vcpkg.exe" install doctest:x64-windows benchmark:x64-windows boost-date-time:x64-windows'
+      run: '& "$Env:VCPKG_INSTALLATION_ROOT/vcpkg.exe" install boost-date-time:x64-windows'
     - name: make build dir
       run: md build
     - name: configure
@@ -69,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev libbenchmark-dev doctest-dev ninja-build cmake build-essential g++-9)
+      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev ninja-build cmake build-essential g++-9)
     - name: make build dir
       run: mkdir build
     - name: configure
@@ -83,7 +83,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: (sudo apt-get update && sudo apt-get install libbenchmark-dev libboost-date-time-dev doctest-dev ninja-build cmake build-essential clang-8)
+      run: (sudo apt-get update && sudo apt-get install libboost-date-time-dev ninja-build cmake build-essential clang-8)
     - name: make build dir
       run: mkdir build
     - name: configure
@@ -97,7 +97,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install dependencies
-      run: '& "$Env:VCPKG_INSTALLATION_ROOT/vcpkg.exe" install doctest:x64-windows benchmark:x64-windows boost-date-time:x64-windows'
+      run: '& "$Env:VCPKG_INSTALLATION_ROOT/vcpkg.exe" install boost-date-time:x64-windows'
     - name: make build dir
       run: md build
     - name: configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,14 +28,46 @@ if (RX_TEST)
     # Release falls back to RelWithDebInfo, then MinSizeRel
     set(CMAKE_MAP_IMPORTED_CONFIG_RELEASE Release RelWithDebInfo MinSizeRel NoConfig "")
 
-    if (APPLE)
-        add_subdirectory(doctest)
-    else()
-        find_package(doctest REQUIRED)
+    # Note: Cloning ad-hoc, because we don't want to add submodules (interfering with other
+    # projects using us as submodule and `--recursive`), and `ExternalProject` does not work well at
+    # all for importing targets from other projects.
+    if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/doctest")
+        message(STATUS "Cloning onqtam/doctest...")
+        execute_process(
+            COMMAND git clone https://github.com/onqtam/doctest.git
+            WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        )
+    endif()
+    if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/benchmark")
+        message(STATUS "Cloning google/benchmark...")
+        execute_process(
+            COMMAND git clone https://github.com/google/benchmark.git
+            WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        )
     endif()
 
+    set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+    set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+    set(BENCHMARK_ENABLE_EXCEPTIONS ON CACHE BOOL "" FORCE)
+    set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+    mark_as_advanced(BENCHMARK_ENABLE_TESTING)
+    mark_as_advanced(BENCHMARK_ENABLE_GTEST_TESTS)
+    mark_as_advanced(BENCHMARK_ENABLE_EXCEPTIONS)
+    mark_as_advanced(BENCHMARK_ENABLE_INSTALL)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+    set(DOCTEST_WITH_TESTS OFF CACHE BOOL "" FORCE)
+    set(DOCTEST_WITH_MAIN_IN_STATIC_LIB OFF CACHE BOOL "" FORCE)
+    set(DOCTEST_NO_INSTALL OFF CACHE BOOL "" FORCE)
+    mark_as_advanced(DOCTEST_WITH_TESTS)
+    mark_as_advanced(DOCTEST_WITH_MAIN_IN_STATIC_LIB)
+    mark_as_advanced(DOCTEST_NO_INSTALL)
+
+    add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/doctest")
+    add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/benchmark")
+
     add_executable(rx-ranges-test test/test_ranges.cpp)
-    target_link_libraries(rx-ranges-test PRIVATE rx::ranges doctest::doctest)
+    target_link_libraries(rx-ranges-test PRIVATE rx::ranges doctest)
     target_compile_definitions(rx-ranges-test PRIVATE "DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN")
     if (WIN32)
         target_compile_definitions(rx-ranges-test PRIVATE "_CRT_SECURE_NO_WARNINGS")
@@ -55,19 +87,10 @@ if (RX_TEST)
     else()
         message(WARNING "Boost not found, not building calendar example")
     endif()
-    find_package(benchmark QUIET)
-    if (benchmark_FOUND)
-        if (UNIX AND NOT APPLE)
-            set(benchmark_LIBS "benchmark")
-        else()
-            set(benchmark_LIBS "benchmark::benchmark")
-        endif()
-        add_executable(rx-benchmark test/benchmark.cpp)
-        if (WIN32)
-            target_compile_definitions(rx-benchmark PRIVATE "_CRT_SECURE_NO_WARNINGS")
-        endif()
-        target_link_libraries(rx-benchmark PRIVATE rx::ranges ${benchmark_LIBS})
-    else()
-        message(WARNING "Google benchmark not found, not building benchmarks")
+
+    add_executable(rx-benchmark test/benchmark.cpp)
+    if (WIN32)
+        target_compile_definitions(rx-benchmark PRIVATE "_CRT_SECURE_NO_WARNINGS")
     endif()
+    target_link_libraries(rx-benchmark PRIVATE rx::ranges benchmark)
 endif()


### PR DESCRIPTION
This is to avoid problems when building with libc++ on Linux.