### PR TITLE
Help GCC 7 with empty_range() deduction guide

### DIFF
--- a/include/rx/ranges.hpp
+++ b/include/rx/ranges.hpp
@@ -2135,7 +2135,7 @@ template <class First, class... InputRanges>
     }
 }
 [[nodiscard]] constexpr auto chain() noexcept {
-    return empty_range();
+    return empty_range<void*>();
 }
 
 /// Create an infinite range repeating the input elements in a loop.


### PR DESCRIPTION
empty_range has a deduction guide: `empty_range()->empty_range<void*>;` so a call to `empty_range()` should create an `empty_range<void*>`. However, GCC 7.3.0 seems to have trouble with this:

```
$ cat empty_range.cc
#include "src/external/rx-ranges/include/rx/ranges.hpp"

$ g++ --version
g++ (crosstool-NG 1.23.0.452-d158) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ g++ -std=c++17 -c empty_range.cc
In file included from empty_range.cc:1:0:
src/external/rx-ranges/include/rx/ranges.hpp: In function 'constexpr auto rx::chain()':
src/external/rx-ranges/include/rx/ranges.hpp:2139:24: error: cannot deduce template arguments for 'empty_range' from ()
     return empty_range();
```