### PR TITLE
Add: member(), return a member variable or the result of a member function

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Algorithms that produce ranges from the output of other ranges.
 - `in_groups_of()`: Produce subranges containing at least one and at most `n` elements.
 - `in_groups_of_exactly()`: Produce subranges containing exactly `n` elements, discarding elements
   at the end if number of input elements is not divisible by `n`.
+- `member()`: Produce a range by returning a member value or calling a member function of the
+  elements of an input range.
 - `skip_n()`: Produce all elements from an input range after skipping `n` elements.
 - `take()`: Produce the first `n` elements of an input range.
 - `tee()`: Copy values of a range into a container during iteration, forwarding the value unmodified

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -327,4 +327,52 @@ static void bench_all_of_std(benchmark::State& state) {
 }
 BENCHMARK(bench_all_of_std);
 
+static void bench_member_rx(benchmark::State& state) {
+    using pair_t = std::pair<int, int>;
+    std::vector<pair_t> input;
+    int n = 0;
+    input.resize(1'000'000);
+    std::generate(begin(input), end(input), [&] { return pair_t{n++,n++}; });
+    for (auto _ : state) {
+        auto f = [](auto begin, auto end) constexpr {
+            return iterator_range(begin, end) | member(&pair_t::first) | sum();
+        };
+        benchmark::DoNotOptimize(f(begin(input), end(input)));
+    }
+}
+BENCHMARK(bench_member_rx);
+
+static void bench_member_transform_rx(benchmark::State& state) {
+    using pair_t = std::pair<int, int>;
+    std::vector<pair_t> input;
+    int n = 0;
+    input.resize(1'000'000);
+    std::generate(begin(input), end(input), [&] { return pair_t{n++,n++}; });
+    for (auto _ : state) {
+        auto f = [](auto begin, auto end) constexpr {
+            return iterator_range(begin, end) | transform([](const auto&p) { return p.first; })
+                   | sum();
+        };
+        benchmark::DoNotOptimize(f(begin(input), end(input)));
+    }
+}
+BENCHMARK(bench_member_transform_rx);
+
+static void bench_member_std(benchmark::State& state) {
+    using pair_t = std::pair<int, int>;
+    std::vector<pair_t> input;
+    int n = 0;
+    input.resize(1'000'000);
+    std::generate(begin(input), end(input), [&] { return pair_t{n++,n++}; });
+    for (auto _ : state) {
+        auto f = [](auto begin, auto end) constexpr {
+            int sum = 0;
+            std::for_each(begin, end, [&](const auto &p) { sum += p.first; });
+            return sum;
+        };
+        benchmark::DoNotOptimize(f(begin(input), end(input)));
+    }
+}
+BENCHMARK(bench_member_std);
+
 BENCHMARK_MAIN();

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -34,6 +34,21 @@ TEST_CASE("range take advance_by overflow") {
     CHECK(arithmetic.i == arithmetic.n);
 }
 
+TEST_CASE("range member variable") {
+    using pair_t = std::pair<int, std::string>;
+    auto input = std::vector{ pair_t{1, "1"s}, pair_t{2, "2"s}, pair_t{3, "3"s}};
+    auto strings = input | member(&pair_t::first) | to_vector();
+    auto expected = std::vector{1, 2, 3};
+    CHECK(strings == expected);
+}
+
+TEST_CASE("range member function") {
+    auto input = std::vector<std::string>{"1", "22", "333", "4444"};
+    auto strings = input | member(&std::string::size) | to_vector();
+    auto expected = std::vector<size_t>{1, 2, 3, 4};
+    CHECK(strings == expected);
+}
+
 TEST_CASE("range transform") {
     auto input = std::vector{{1, 2, 3, 4}};
     auto strings = input | transform(&to_string<int>) | to_vector();


### PR DESCRIPTION
member() is a simple combinator that I find more readable than a call to transform with a lambda to return a member variable or the result of the call to a member function.