### PR TITLE
Explicitly include cmath for std::sqrt

### DIFF
--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,6 +1,7 @@
 #include <rx/ranges.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
On a Fedora 42 Beta machine, building tests with g++ 15.0.1 and doctest 2.4.11 fails:
```
test_ranges.cpp: In member function ‘constexpr void {anonymous}::normalize::Range<Input>::sink(Out&) &&’:
test_ranges.cpp:784:32: error: ‘sqrt’ is not a member of ‘std’; did you mean ‘sort’? [-Wtemplate-body]
  784 |             auto length = std::sqrt(out | transform(square) | sum());
      |                                ^~~~
      |                                sort
```

Explicitly `#include <cmath>` to be sure that `std::sqrt` is defined.